### PR TITLE
Added script for adding bootstrap IPFS nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# Bootstrap Nodes
+
+A list of trusted bootstrap IPFS nodes to aid in the discovery of OpenMined workers
+
+## Adding Bootstrap Nodes
+```
+bin/add_bootstrap_nodes
+```
+
+## Connecting To Known Workers
+Your `ipfs daemon` must be running
+
+```
+bin/connect_workers
+```

--- a/bin/add_bootstrap_nodes
+++ b/bin/add_bootstrap_nodes
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+BOOTSTRAP_NODES_PATH="$( cd "$(dirname "$0")" ; pwd -P )/../bootstrap_nodes"
+cat $BOOTSTRAP_NODES_PATH | xargs ipfs bootstrap add

--- a/bin/connect_workers
+++ b/bin/connect_workers
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+KNOWN_WORKERS_PATH="$( cd "$(dirname "$0")" ; pwd -P )/../known_workers"
+cat $KNOWN_WORKERS_PATH | xargs ipfs swarm connect


### PR DESCRIPTION
And for connecting to known workers.
We could add the bin directory to the users' path so we can call the
`add_bootrap_nodes` script from the `start_ipfs` script in Grid but I
decided to keep it simple for now.

Following on from my previous PR:
https://github.com/OpenMined/Grid/pull/65