### PR TITLE
New anchor node on GCP

### DIFF
--- a/known_workers
+++ b/known_workers
@@ -1,2 +1,3 @@
 /p2p-circuit/ipfs/QmQabt3SWuDvjse9z7GAcH2BGQv4wH8bumkd4x5oXN2obX
 /p2p-circuit/ipfs/Qmaosc64H6Y29VFCFYJzJXCX9AuRp7RCsekLmajHNVEARD
+/p2p-circuit/ipfs/QmXkWUybbTnfvFH8SUcrug6RGTLYTB23gSockKLxueR1vQ


### PR DESCRIPTION
added this since the other anchors went down somehow.  I can keep this node running for close to a year on free creds